### PR TITLE
User connection Tracking

### DIFF
--- a/src/Heisenslaught/Config/MongoSettings.cs
+++ b/src/Heisenslaught/Config/MongoSettings.cs
@@ -1,13 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace Heisenslaught.Config
+﻿namespace Heisenslaught.Config
 {
     public class MongoSettings
     {
-
         public string ConnectionString { get; set; }
         public string Database { get; set; }
     }

--- a/src/Heisenslaught/Config/UserCreationSettings.cs
+++ b/src/Heisenslaught/Config/UserCreationSettings.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+
 
 namespace Heisenslaught.Config
 {

--- a/src/Heisenslaught/Controllers/AngularController.cs
+++ b/src/Heisenslaught/Controllers/AngularController.cs
@@ -1,17 +1,10 @@
-﻿using System;
-using System.IO;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Identity;
+﻿using Heisenslaught.DataTransfer.Users;
 using Heisenslaught.Models.Users;
-using Heisenslaught.DataTransfer.Users;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
-
-
-// For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
 namespace Heisenslaught.Controllers
 {
@@ -23,7 +16,6 @@ namespace Heisenslaught.Controllers
         {
             _userManager = userManager;
         }
-        //public FileResult Index()
 
         public async Task<IActionResult> Index()
         {

--- a/src/Heisenslaught/Controllers/AuthAPIController.cs
+++ b/src/Heisenslaught/Controllers/AuthAPIController.cs
@@ -11,7 +11,7 @@ namespace Heisenslaught.Controllers
     [Route("api/auth")]
     public class AuthAPIController : Controller
     {
-        public AuthAPIController(IDraftService service)
+        public AuthAPIController(IDraftService service, IHubConnectionsService hcs)
         {
             var a = service;
         }

--- a/src/Heisenslaught/Controllers/AuthController.cs
+++ b/src/Heisenslaught/Controllers/AuthController.cs
@@ -1,18 +1,12 @@
-﻿using System;
-using System.IO;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
+﻿using Heisenslaught.Config;
+using Heisenslaught.DataTransfer.Users;
+using Heisenslaught.Models.Users;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
-using Heisenslaught.Models.Users;
-using Newtonsoft.Json;
-using Heisenslaught.DataTransfer.Users;
-using Heisenslaught.Config;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using System.Threading.Tasks;
 
-// For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
 namespace Heisenslaught.Controllers
 {
@@ -46,7 +40,6 @@ namespace Heisenslaught.Controllers
 
         [HttpGet]
         [AllowAnonymous]
-        //https://localhost:44301/
         public async Task<IActionResult> CallbackAsync(string returnUrl = null, string remoteError = null)
         {
             if (remoteError != null)
@@ -107,7 +100,6 @@ namespace Heisenslaught.Controllers
                 return View("LoginEvent");
             }
         }
-
 
         [HttpGet]
         public async Task<bool> Logout()

--- a/src/Heisenslaught/DataTransfer/CreateDraftDTO.cs
+++ b/src/Heisenslaught/DataTransfer/CreateDraftDTO.cs
@@ -1,8 +1,5 @@
-﻿using System;
+﻿using Heisenslaught.Models;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Heisenslaught.Models;
 
 
 namespace Heisenslaught.DataTransfer

--- a/src/Heisenslaught/DataTransfer/DraftConfigAdminDTO.cs
+++ b/src/Heisenslaught/DataTransfer/DraftConfigAdminDTO.cs
@@ -1,5 +1,5 @@
-﻿using Heisenslaught.Models;
-using Heisenslaught.Infrastructure;
+﻿using Heisenslaught.Infrastructure;
+using Heisenslaught.Models;
 
 
 namespace Heisenslaught.DataTransfer

--- a/src/Heisenslaught/DataTransfer/DraftConfigDTO.cs
+++ b/src/Heisenslaught/DataTransfer/DraftConfigDTO.cs
@@ -1,5 +1,5 @@
-﻿using Heisenslaught.Models;
-using Heisenslaught.Infrastructure;
+﻿using Heisenslaught.Infrastructure;
+using Heisenslaught.Models;
 
 
 namespace Heisenslaught.DataTransfer

--- a/src/Heisenslaught/DataTransfer/DraftConfigDrafterDTO.cs
+++ b/src/Heisenslaught/DataTransfer/DraftConfigDrafterDTO.cs
@@ -1,5 +1,5 @@
-﻿using Heisenslaught.Models;
-using Heisenslaught.Infrastructure;
+﻿using Heisenslaught.Infrastructure;
+using Heisenslaught.Models;
 
 
 namespace Heisenslaught.DataTransfer

--- a/src/Heisenslaught/DataTransfer/DraftStateDTO.cs
+++ b/src/Heisenslaught/DataTransfer/DraftStateDTO.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using Heisenslaught.Infrastructure;
 using Heisenslaught.Models;
-using Heisenslaught.Infrastructure;
+using System.Collections.Generic;
 
 
 namespace Heisenslaught.DataTransfer

--- a/src/Heisenslaught/DataTransfer/Users/AuthenticatedUserDTO.cs
+++ b/src/Heisenslaught/DataTransfer/Users/AuthenticatedUserDTO.cs
@@ -1,8 +1,6 @@
-﻿using System;
+﻿using Heisenslaught.Models.Users;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
-using Heisenslaught.Models.Users;
 
 namespace Heisenslaught.DataTransfer.Users
 {

--- a/src/Heisenslaught/DataTransfer/Users/LoginResultDTO.cs
+++ b/src/Heisenslaught/DataTransfer/Users/LoginResultDTO.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace Heisenslaught.DataTransfer.Users
+﻿namespace Heisenslaught.DataTransfer.Users
 {
     public class LoginResultDTO<TData>
     {

--- a/src/Heisenslaught/DataTransfer/Users/UserBaseDTO.cs
+++ b/src/Heisenslaught/DataTransfer/Users/UserBaseDTO.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Heisenslaught.Models.Users;
+﻿using Heisenslaught.Models.Users;
 
 namespace Heisenslaught.DataTransfer.Users
 {

--- a/src/Heisenslaught/GlobalSuppressions.cs
+++ b/src/Heisenslaught/GlobalSuppressions.cs
@@ -6,4 +6,6 @@
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>", Scope = "member", Target = "~M:Heisenslaught.Controllers.AngularController.Index~System.Threading.Tasks.Task{Microsoft.AspNetCore.Mvc.IActionResult}")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>", Scope = "member", Target = "~M:Heisenslaught.Controllers.AuthController.Logout~System.Threading.Tasks.Task{System.Boolean}")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>", Scope = "member", Target = "~M:Heisenslaught.Hubs.UserAwareHub.OnConnected~System.Threading.Tasks.Task")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>", Scope = "member", Target = "~M:Heisenslaught.Hubs.UserAwareHub.OnDisconnected(System.Boolean)~System.Threading.Tasks.Task")]
 

--- a/src/Heisenslaught/GlobalSuppressions.cs
+++ b/src/Heisenslaught/GlobalSuppressions.cs
@@ -8,4 +8,5 @@
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>", Scope = "member", Target = "~M:Heisenslaught.Controllers.AuthController.Logout~System.Threading.Tasks.Task{System.Boolean}")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>", Scope = "member", Target = "~M:Heisenslaught.Hubs.UserAwareHub.OnConnected~System.Threading.Tasks.Task")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>", Scope = "member", Target = "~M:Heisenslaught.Hubs.UserAwareHub.OnDisconnected(System.Boolean)~System.Threading.Tasks.Task")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>", Scope = "member", Target = "~M:Heisenslaught.Hubs.UserAwareHub.OnUserConnected~System.Threading.Tasks.Task")]
 

--- a/src/Heisenslaught/Hubs/DraftHub.cs
+++ b/src/Heisenslaught/Hubs/DraftHub.cs
@@ -5,24 +5,21 @@ using Heisenslaught.Models.Users;
 using Heisenslaught.Services;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.SignalR.Hubs;
 using System;
 using System.Threading.Tasks;
 
 
 namespace Heisenslaught
 {
-    public class DraftHub : Hub
+    public class DraftHub : UserAwareHub
     {
 
         private readonly IDraftService _draftService;
-        private readonly UserManager<HSUser> userManager;
-        private readonly IHubConnectionsService connectionService;
-
-        public DraftHub(IDraftService draftService, IHubConnectionsService connectionService, UserManager<HSUser> userManager) 
+    
+        public DraftHub(IDraftService draftService, IHubConnectionsService connectionService, UserManager<HSUser> userManager) : base(connectionService, userManager)
         {
             _draftService = draftService;
-            this.userManager = userManager;
-            this.connectionService = connectionService;
         }
 
         public override Task OnDisconnected(bool stopCalled)
@@ -31,14 +28,16 @@ namespace Heisenslaught
             return base.OnDisconnected(stopCalled);
         }
 
-        public async Task<DraftConfigAdminDTO> CreateDraft(CreateDraftDTO cfg)
+        [HubMethodName("createDraft")]
+        public async Task<DraftConfigAdminDTO> CreateDraftAsync(CreateDraftDTO cfg)
         {
-            return await _draftService.CreateDraft(cfg, this);
+            return await _draftService.CreateDraftAsync(cfg, this);
         }
 
-        public DraftConfigDTO ConnectToDraft(string draftToken, string teamToken = null)
+        [HubMethodName("connectToDraft")]
+        public async Task<DraftConfigDTO> ConnectToDraftAsync(string draftToken, string teamToken = null)
         {
-            return _draftService.ConnectToDraft(this, draftToken, teamToken);
+            return await _draftService.ConnectToDraftAsync(this, draftToken, teamToken);
         }
 
         public DraftConfigAdminDTO RestartDraft(string draftToken, string adminToken)

--- a/src/Heisenslaught/Hubs/DraftHub.cs
+++ b/src/Heisenslaught/Hubs/DraftHub.cs
@@ -1,22 +1,23 @@
-﻿using Microsoft.AspNetCore.SignalR;
-using System;
-using System.Threading.Tasks;
-using Heisenslaught.DataTransfer;
+﻿using Heisenslaught.DataTransfer;
 using Heisenslaught.Exceptions;
+using Heisenslaught.Hubs;
+using Heisenslaught.Models.Users;
 using Heisenslaught.Services;
 using Microsoft.AspNetCore.Identity;
-using Heisenslaught.Models.Users;
+using Microsoft.AspNetCore.SignalR;
+using System;
+using System.Threading.Tasks;
+
+
 namespace Heisenslaught
 {
-    public class DraftHub : Hub
+    public class DraftHub : UserAwareHub
     {
 
         private readonly IDraftService _draftService;
-        private readonly UserManager<HSUser> _userManager;
-        
-        public DraftHub(UserManager<HSUser> userManager, IDraftService draftService)
+       
+        public DraftHub(UserManager<HSUser> userManager, IDraftService draftService, IHubConnectionsService connectionService) :base (connectionService, userManager)
         {
-            _userManager = userManager;
             _draftService = draftService;
         }
 

--- a/src/Heisenslaught/Hubs/DraftHub.cs
+++ b/src/Heisenslaught/Hubs/DraftHub.cs
@@ -11,14 +11,18 @@ using System.Threading.Tasks;
 
 namespace Heisenslaught
 {
-    public class DraftHub : UserAwareHub
+    public class DraftHub : Hub
     {
 
         private readonly IDraftService _draftService;
-       
-        public DraftHub(UserManager<HSUser> userManager, IDraftService draftService, IHubConnectionsService connectionService) :base (connectionService, userManager)
+        private readonly UserManager<HSUser> userManager;
+        private readonly IHubConnectionsService connectionService;
+
+        public DraftHub(IDraftService draftService, IHubConnectionsService connectionService, UserManager<HSUser> userManager) 
         {
             _draftService = draftService;
+            this.userManager = userManager;
+            this.connectionService = connectionService;
         }
 
         public override Task OnDisconnected(bool stopCalled)

--- a/src/Heisenslaught/Hubs/DraftHub.cs
+++ b/src/Heisenslaught/Hubs/DraftHub.cs
@@ -4,7 +4,6 @@ using Heisenslaught.Hubs;
 using Heisenslaught.Models.Users;
 using Heisenslaught.Services;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Hubs;
 using System;
 using System.Threading.Tasks;
@@ -14,7 +13,6 @@ namespace Heisenslaught
 {
     public class DraftHub : UserAwareHub
     {
-
         private readonly IDraftService _draftService;
     
         public DraftHub(IDraftService draftService, IHubConnectionsService connectionService, UserManager<HSUser> userManager) : base(connectionService, userManager)

--- a/src/Heisenslaught/Hubs/UserAwareHub.cs
+++ b/src/Heisenslaught/Hubs/UserAwareHub.cs
@@ -25,12 +25,11 @@ namespace Heisenslaught.Hubs
 
         public override Task OnConnected()
         {
-
-           OnUserConnected();
+           OnUserConnectedAsync().Wait();
            return base.OnConnected();
         }
 
-        protected async Task OnUserConnected()
+        protected async Task OnUserConnectedAsync()
         {
             var user = await userManager.GetUserAsync((ClaimsPrincipal)Context.User);
             connectionService.OnUserConnected(user, this);

--- a/src/Heisenslaught/Hubs/UserAwareHub.cs
+++ b/src/Heisenslaught/Hubs/UserAwareHub.cs
@@ -20,14 +20,17 @@ namespace Heisenslaught.Hubs
 
         public override Task OnConnected()
         {
-           OnUserConnectedAsync().Wait();
-           return base.OnConnected();
+            #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            OnUserConnectedAsync();
+            #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            return base.OnConnected();
         }
 
-        protected async Task OnUserConnectedAsync()
+        protected async Task<bool> OnUserConnectedAsync()
         {
             var user = await userManager.GetUserAsync((ClaimsPrincipal)Context.User);
             connectionService.OnUserConnected(user, this);
+            return true;
         }
 
         public override async Task OnDisconnected(bool stopCalled)

--- a/src/Heisenslaught/Hubs/UserAwareHub.cs
+++ b/src/Heisenslaught/Hubs/UserAwareHub.cs
@@ -1,13 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.SignalR;
-using Microsoft.AspNetCore.SignalR.Server;
+﻿using Heisenslaught.Models.Users;
 using Heisenslaught.Services;
 using Microsoft.AspNetCore.Identity;
-using Heisenslaught.Models.Users;
+using Microsoft.AspNetCore.SignalR;
 using System.Security.Claims;
+using System.Threading.Tasks;
 
 namespace Heisenslaught.Hubs
 {
@@ -21,7 +17,6 @@ namespace Heisenslaught.Hubs
             this.connectionService = connectionService;
             this.userManager = userManager;
         }
-
 
         public override Task OnConnected()
         {
@@ -41,6 +36,5 @@ namespace Heisenslaught.Hubs
             connectionService.OnUserDisconnected(user, this);
             await base.OnDisconnected(stopCalled);
         }
-
     }
 }

--- a/src/Heisenslaught/Hubs/UserAwareHub.cs
+++ b/src/Heisenslaught/Hubs/UserAwareHub.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.SignalR.Server;
 using Heisenslaught.Services;
 using Microsoft.AspNetCore.Identity;
 using Heisenslaught.Models.Users;
@@ -22,11 +23,17 @@ namespace Heisenslaught.Hubs
         }
 
 
-        public override async Task OnConnected()
+        public override Task OnConnected()
+        {
+
+           OnUserConnected();
+           return base.OnConnected();
+        }
+
+        protected async Task OnUserConnected()
         {
             var user = await userManager.GetUserAsync((ClaimsPrincipal)Context.User);
             connectionService.OnUserConnected(user, this);
-            await base.OnConnected();
         }
 
         public override async Task OnDisconnected(bool stopCalled)

--- a/src/Heisenslaught/Hubs/UserAwareHub.cs
+++ b/src/Heisenslaught/Hubs/UserAwareHub.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Heisenslaught.Services;
+using Microsoft.AspNetCore.Identity;
+using Heisenslaught.Models.Users;
+using System.Security.Claims;
+
+namespace Heisenslaught.Hubs
+{
+    public abstract class UserAwareHub : Hub
+    {
+        protected readonly IHubConnectionsService connectionService;
+        protected readonly UserManager<HSUser> userManager;
+
+        public UserAwareHub(IHubConnectionsService connectionService, UserManager<HSUser> userManager) : base()
+        {
+            this.connectionService = connectionService;
+            this.userManager = userManager;
+        }
+
+
+        public override async Task OnConnected()
+        {
+            var user = await userManager.GetUserAsync((ClaimsPrincipal)Context.User);
+            connectionService.OnUserConnected(user, this);
+            await base.OnConnected();
+        }
+
+        public override async Task OnDisconnected(bool stopCalled)
+        {
+            var user = await userManager.GetUserAsync((ClaimsPrincipal)Context.User);
+            connectionService.OnUserDisconnected(user, this);
+            await base.OnDisconnected(stopCalled);
+        }
+
+    }
+}

--- a/src/Heisenslaught/Infrastructure/DraftHandler.cs
+++ b/src/Heisenslaught/Infrastructure/DraftHandler.cs
@@ -1,17 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Threading;
-using Heisenslaught.Models;
+﻿using Heisenslaught.Models;
 using Heisenslaught.Services;
+using System;
+using System.Collections.Generic;
 
 namespace Heisenslaught.Infrastructure
 {
     public class DraftHandler
     {
-        private readonly IHeroDataService _heroDataService;
-
         private static Random rnd = new Random((int)DateTime.Now.Ticks);
         private static List<int> firstSlots= new List<int>{0,2,5,6,8,11,12};
         private static List<int> secondSlots = new List<int> {1,2,3,7,9,10,13};
@@ -19,6 +14,8 @@ namespace Heisenslaught.Infrastructure
         private static List<int> secondPickSlots = new List<int> {3,4,9,10,13};
         private static List<int> firstBanSlots = new List<int> {0,8};
         private static List<int> secondBanSlots = new List<int> {1,7};
+
+        private readonly IHeroDataService _heroDataService; 
 
         private List<List<int>> teamSlots = new List<List<int>>();
         private List<List<int>> teamPickSlots = new List<List<int>>();

--- a/src/Heisenslaught/Infrastructure/DraftHandler.cs
+++ b/src/Heisenslaught/Infrastructure/DraftHandler.cs
@@ -10,7 +10,7 @@ namespace Heisenslaught.Infrastructure
 {
     public class DraftHandler
     {
-        private readonly HeroDataService _heroDataService;
+        private readonly IHeroDataService _heroDataService;
 
         private static Random rnd = new Random((int)DateTime.Now.Ticks);
         private static List<int> firstSlots= new List<int>{0,2,5,6,8,11,12};
@@ -27,7 +27,7 @@ namespace Heisenslaught.Infrastructure
         private DraftModel model;
 
 
-        public DraftHandler(DraftRoom draftRoom, HeroDataService heroDataService)
+        public DraftHandler(DraftRoom draftRoom, IHeroDataService heroDataService)
         {
             _heroDataService = heroDataService;
             this.model = draftRoom.DraftModel;

--- a/src/Heisenslaught/Infrastructure/DraftRoom.cs
+++ b/src/Heisenslaught/Infrastructure/DraftRoom.cs
@@ -1,13 +1,12 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
-using System.Threading;
-using Heisenslaught.Models;
-using Heisenslaught.Services;
+﻿using Heisenslaught.DataTransfer;
 using Heisenslaught.Exceptions;
-using Heisenslaught.DataTransfer;
+using Heisenslaught.Models;
 using Heisenslaught.Models.Users;
-using System.Linq;
+using Heisenslaught.Services;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 
 namespace Heisenslaught.Infrastructure
 {
@@ -16,14 +15,11 @@ namespace Heisenslaught.Infrastructure
         private readonly IHeroDataService _heroDataService;
         private readonly IHubConnectionsService _conService;
 
-       // private Dictionary<string, DraftRoomConnection> connections = new Dictionary<string, DraftRoomConnection>();
-
         private DraftHandler draftHandler;
         private DraftModel model;
         private DraftService service;
         private Timer timer;
 
-        public string RoomName { get; private set; }
 
         public DraftRoom(DraftService service, IHeroDataService heroDataService, IHubConnectionsService conService, DraftModel model)
         {
@@ -34,6 +30,8 @@ namespace Heisenslaught.Infrastructure
             this.RoomName = "draftRoom-" + model.draftToken;
             this.draftHandler = new DraftHandler(this, _heroDataService);
         }
+
+        public string RoomName { get; private set; }
 
         public DraftModel DraftModel
         {
@@ -69,7 +67,6 @@ namespace Heisenslaught.Infrastructure
             UpdateDraftState(hub);
         }
 
-
         protected IEnumerable<DraftRoomConnection> _getDraftConnections(string userId = null)
         {
             var result =_conService.Query<IEnumerable<DraftRoomConnection>>((List<HubChannelConnection> cons) => {
@@ -78,9 +75,9 @@ namespace Heisenslaught.Infrastructure
                         group c by c.Connection.User.Id into usrGroup
 
                         select new DraftRoomConnection {
-                            Id = usrGroup.FirstOrDefault().Connection.User.Id,
-                            Name = usrGroup.FirstOrDefault().Connection.User.BattleTagDisplay,
-                            ConnectionTypes = usrGroup.Select(t=> t.Flag).Distinct().Sum()
+                            id = usrGroup.FirstOrDefault().Connection.User.Id,
+                            name = usrGroup.FirstOrDefault().Connection.User.BattleTagDisplay,
+                            connectionTypes = usrGroup.Select(t=> t.Flag).Distinct().Sum()
                         };
                 return q;
             });
@@ -95,9 +92,7 @@ namespace Heisenslaught.Infrastructure
         protected List<DraftRoomConnection> GetDraftConnections()
         {
             return _getDraftConnections().ToList();
-         }
-
-
+        }
 
         public int ConnectionCount
         {
@@ -227,7 +222,6 @@ namespace Heisenslaught.Infrastructure
             UpdateDraftState(hub);
         }
 
-
         private void UpdateDraftState(DraftHub hub)
         {
             hub.Clients.Group(RoomName).updateDraftState(new DraftStateDTO(this));
@@ -265,7 +259,6 @@ namespace Heisenslaught.Infrastructure
         {
             service.CompleteDraft(this);
         }
-
     }
 
     [Flags]
@@ -279,8 +272,8 @@ namespace Heisenslaught.Infrastructure
 
     public class DraftRoomConnection
     {
-        public string Id;
-        public string Name;
-        public int ConnectionTypes;
+        public string id;
+        public string name;
+        public int connectionTypes;
     }
 }

--- a/src/Heisenslaught/Infrastructure/DraftRoom.cs
+++ b/src/Heisenslaught/Infrastructure/DraftRoom.cs
@@ -64,6 +64,10 @@ namespace Heisenslaught.Infrastructure
                 // send user left message
                 hub.Clients.Group(RoomName, new string[] { hub.Context.ConnectionId }).OnUserLeft(connection);
             }
+            else
+            {
+                hub.Clients.Group(RoomName, new string[] { hub.Context.ConnectionId }).OnUserStatusUpdate(GetDraftConnection(user.Id));
+            }
             UpdateDraftState(hub);
         }
 

--- a/src/Heisenslaught/Infrastructure/DraftRoom.cs
+++ b/src/Heisenslaught/Infrastructure/DraftRoom.cs
@@ -10,7 +10,7 @@ namespace Heisenslaught.Infrastructure
 {
     public class DraftRoom
     {
-        private readonly HeroDataService _heroDataService;
+        private readonly IHeroDataService _heroDataService;
         private Dictionary<string, DraftRoomConnection> connections = new Dictionary<string, DraftRoomConnection>();
         private DraftHandler draftHandler;
         private DraftModel model;
@@ -18,7 +18,7 @@ namespace Heisenslaught.Infrastructure
         private DraftService service;
         private Timer timer;
 
-        public DraftRoom(DraftService service, HeroDataService heroDataService, DraftModel model)
+        public DraftRoom(DraftService service, IHeroDataService heroDataService, DraftModel model)
         {
             this.service = service;
             _heroDataService = heroDataService;

--- a/src/Heisenslaught/Models/DraftConfigModel.cs
+++ b/src/Heisenslaught/Models/DraftConfigModel.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace Heisenslaught.Models
 {

--- a/src/Heisenslaught/Models/DraftModel.cs
+++ b/src/Heisenslaught/Models/DraftModel.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using MongoDB.Bson;
-using Heisenslaught.Infrastructure;
+﻿using MongoDB.Bson;
+using System;
 
 namespace Heisenslaught.Models
 {

--- a/src/Heisenslaught/Models/DraftStateModel.cs
+++ b/src/Heisenslaught/Models/DraftStateModel.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace Heisenslaught.Models
 {

--- a/src/Heisenslaught/Models/Users/HSEmailAddress.cs
+++ b/src/Heisenslaught/Models/Users/HSEmailAddress.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Heisenslaught.Models.Users
 {

--- a/src/Heisenslaught/Models/Users/HSRole.cs
+++ b/src/Heisenslaught/Models/Users/HSRole.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using MongoDB.Bson;
+﻿using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 
 

--- a/src/Heisenslaught/Models/Users/HSUser.cs
+++ b/src/Heisenslaught/Models/Users/HSUser.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Identity;
-using MongoDB.Bson;
+﻿using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+
 
 namespace Heisenslaught.Models.Users
 {
@@ -19,8 +17,6 @@ namespace Heisenslaught.Models.Users
         public string BattleTag { get; private set; }
         public string BattleTagNormaized { get; private set; }
         public string BattleTagDisplay { get; private set; }
-
-
 
         // for later
         public string PasswordHash;
@@ -72,7 +68,7 @@ namespace Heisenslaught.Models.Users
 
         public void AddLogin(HSUserLogin login)
         {
-            this._logins.Add(login);
+            _logins.Add(login);
         }
 
         public bool RemoveLogin(HSUserLogin login)

--- a/src/Heisenslaught/Models/Users/HSUser.cs
+++ b/src/Heisenslaught/Models/Users/HSUser.cs
@@ -8,7 +8,7 @@ using MongoDB.Bson.Serialization.Attributes;
 
 namespace Heisenslaught.Models.Users
 {
-    public class HSUser
+    public class HSUser : IEquatable<HSUser>
     {
         private List<HSUserLogin> _logins;
         private List<string> _roles;
@@ -123,6 +123,11 @@ namespace Heisenslaught.Models.Users
                 return true;
             }
             return !PrimaryEmail.IsConfirmed();
+        }
+
+        public bool Equals(HSUser other)
+        {
+            return other.Id == Id;
         }
     }
 }

--- a/src/Heisenslaught/Models/Users/HSUserLogin.cs
+++ b/src/Heisenslaught/Models/Users/HSUserLogin.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Identity;
+﻿using Microsoft.AspNetCore.Identity;
+using System;
 
 namespace Heisenslaught.Models.Users
 {

--- a/src/Heisenslaught/Models/Users/HSUserValidator.cs
+++ b/src/Heisenslaught/Models/Users/HSUserValidator.cs
@@ -1,16 +1,11 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.Identity;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Text.RegularExpressions;
-
-using Microsoft.AspNetCore.Identity;
+using System.Threading.Tasks;
 
 namespace Heisenslaught.Models.Users
 {
-        
-        
-        
     public class HSUserValidator : IUserValidator<HSUser>
     {
         private static readonly Regex BattleTagRegexp = new Regex("^\\d+#\\d+", RegexOptions.Compiled | RegexOptions.IgnoreCase);

--- a/src/Heisenslaught/Persistence/Draft/DraftStore.cs
+++ b/src/Heisenslaught/Persistence/Draft/DraftStore.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using MongoDB.Driver;
-using MongoDB.Bson;
+﻿using Heisenslaught.Models;
 using Microsoft.Extensions.Logging;
-using Heisenslaught.Models;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using System.Linq;
 
 namespace Heisenslaught.Persistence.Draft
 {

--- a/src/Heisenslaught/Persistence/Users/HSRoleStore.cs
+++ b/src/Heisenslaught/Persistence/Users/HSRoleStore.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using Heisenslaught.Models.Users;
 using Microsoft.AspNetCore.Identity;
-using Heisenslaught.Models.Users;
-using System.Threading;
-using MongoDB.Driver;
 using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Heisenslaught.Persistence.User
 {

--- a/src/Heisenslaught/Persistence/Users/HSUserStore.cs
+++ b/src/Heisenslaught/Persistence/Users/HSUserStore.cs
@@ -1,13 +1,12 @@
-﻿using System;
+﻿using Heisenslaught.Models.Users;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Identity;
-using Heisenslaught.Models.Users;
 using System.Threading;
-using Microsoft.Extensions.Logging;
-
-using MongoDB.Driver;
+using System.Threading.Tasks;
 
 namespace Heisenslaught.Persistence.User
 {

--- a/src/Heisenslaught/Services/DraftService.cs
+++ b/src/Heisenslaught/Services/DraftService.cs
@@ -1,15 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using Heisenslaught.DataTransfer;
 using Heisenslaught.Infrastructure;
 using Heisenslaught.Models;
-using Heisenslaught.DataTransfer;
-using Microsoft.AspNetCore.SignalR.Hubs;
+using Heisenslaught.Models.Users;
 using Heisenslaught.Persistence.Draft;
 using Microsoft.AspNetCore.Identity;
-using Heisenslaught.Models.Users;
+using System;
+using System.Collections.Generic;
 using System.Security.Claims;
+using System.Threading.Tasks;
+
 
 namespace Heisenslaught.Services
 {
@@ -83,7 +82,6 @@ namespace Heisenslaught.Services
             return room;
         }
 
-
         public void ClientDisconnected(DraftHub hub)
         {
             DraftRoom room = null;
@@ -104,7 +102,6 @@ namespace Heisenslaught.Services
             _draftStore.SaveDraft(room.DraftModel);
             TryDeactivateDraftRoom(room);
         }
-
 
         private void TryActivateDraftRoom(DraftRoom room)
         {
@@ -130,6 +127,5 @@ namespace Heisenslaught.Services
                 }
             }
         }
-
     }
 }

--- a/src/Heisenslaught/Services/DraftService.cs
+++ b/src/Heisenslaught/Services/DraftService.cs
@@ -16,14 +16,14 @@ namespace Heisenslaught.Services
     public class DraftService : IDraftService
     {
         private readonly IDraftStore _draftStore;
-        private readonly HeroDataService _heroDataService;
+        private readonly IHeroDataService _heroDataService;
         private readonly UserManager<HSUser> _userManager;
 
         private Dictionary<string, DraftRoom> activeRooms = new Dictionary<string, DraftRoom>();
         private Dictionary<string, DraftRoom> connectionsRoom = new Dictionary<string, DraftRoom>();
 
 
-        public DraftService(IDraftStore draftStore, HeroDataService heroDataService, UserManager<HSUser> userManager)
+        public DraftService(IDraftStore draftStore, IHeroDataService heroDataService, UserManager<HSUser> userManager)
         {
             _draftStore = draftStore;
             _heroDataService = heroDataService;

--- a/src/Heisenslaught/Services/DraftService.cs
+++ b/src/Heisenslaught/Services/DraftService.cs
@@ -54,13 +54,15 @@ namespace Heisenslaught.Services
             var connectionType = room.Connect(hub, user, authToken);
 
             TryActivateDraftRoom(room);
+            
 
             switch (connectionType)
             {
                 case DraftConnectionType.ADMIN:
                     config = new DraftConfigAdminDTO(room);
                     break;
-                case DraftConnectionType.DRAFTER:
+                case DraftConnectionType.DRAFTER_TEAM_1:
+                case DraftConnectionType.DRAFTER_TEAM_2:
                     config = new DraftConfigDrafterDTO(room, authToken);
                     break;
                 case DraftConnectionType.OBSERVER:

--- a/src/Heisenslaught/Services/HeroDataService.cs
+++ b/src/Heisenslaught/Services/HeroDataService.cs
@@ -23,7 +23,7 @@ namespace Heisenslaught.Services
         public string name;
     }
 
-    public class HeroDataService
+    public class HeroDataService : IHeroDataService
     {
         public List<HeroData> heroesData;
         public List<MapData> mapsData;

--- a/src/Heisenslaught/Services/HeroDataService.cs
+++ b/src/Heisenslaught/Services/HeroDataService.cs
@@ -1,12 +1,10 @@
-﻿using System;
+﻿using Newtonsoft.Json;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
 using System.IO;
+
+
 namespace Heisenslaught.Services
 {
-
     public class HeroData
     {
         public string id;

--- a/src/Heisenslaught/Services/HubConnectionsService.cs
+++ b/src/Heisenslaught/Services/HubConnectionsService.cs
@@ -1,0 +1,302 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Collections.Concurrent;
+
+using System.Threading;
+using Heisenslaught.Models.Users;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Heisenslaught.Services
+{
+    public class HubConnection{
+        public Type HubType;
+        public string ConnectionId;
+        public HSUser User; 
+
+        public HubConnection(HSUser user, Hub hub)
+        {
+            HubType = hub.GetType();
+            ConnectionId = hub.Context.ConnectionId;
+            User = user;
+        }
+    }
+
+    public class HubChannelConnection
+    {
+        public HubConnection Connection;
+        public string ChannelName;
+
+        public HubChannelConnection(HubConnection connection, string channelName)
+        {
+            Connection = connection;
+            ChannelName = channelName;
+        }
+    }
+    
+    public class HubConnectionsService : IHubConnectionsService
+    {
+
+        private readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
+
+        private readonly Dictionary<string, HSUser> _connectedUsers = new Dictionary<string, HSUser>();
+        private readonly List<HubConnection> _hubConnections = new List<HubConnection>();
+        private readonly List<HubChannelConnection> _channelConnections = new List<HubChannelConnection>();
+
+
+        private HubConnection FindHubConnection(Hub hub)
+        {
+            return (from c in _hubConnections
+                    where c.HubType == hub.GetType() && c.ConnectionId == hub.Context.ConnectionId
+                    select c).First();
+        }
+
+        private IEnumerable<HubConnection> FindHubConnectionByUserId(string userId)
+        {
+            return from c in _hubConnections
+                   where c.User.Id == userId
+                   select c;
+        }
+
+        private IEnumerable<HubChannelConnection> FindChannelConnectionsByUserId(string userId)
+        {
+            return from c in _channelConnections
+                   where c.Connection.User.Id == userId
+                   select c;
+        }
+
+        private HubChannelConnection FindChannelConnection(Hub hub, string channelName)
+        {
+            return (from c in _channelConnections
+                    where c.ChannelName == channelName && c.Connection.HubType == hub.GetType() && c.Connection.ConnectionId == hub.Context.ConnectionId
+                    select c).First();
+        }
+
+        private HSUser GetConnectedUser(string userId)
+        {
+            if (IsUserConnected(userId))
+                return _connectedUsers[userId];
+            return null;
+        }
+
+        public HubConnection OnUserConnected(HSUser user, Hub hub)
+        {
+            _lock.EnterWriteLock();
+            try
+            {
+
+                var hubConnection = FindHubConnection(hub);
+                if (hubConnection == null)
+                {
+                    var u = GetConnectedUser(user.Id);
+                    if (u == null)
+                    {
+                        u = user;
+                        _connectedUsers.Add(u.Id, u);
+                    }
+                    hubConnection = new HubConnection(u, hub);
+                    _hubConnections.Add(hubConnection);
+                }
+                return hubConnection;
+            }
+            finally
+            {
+                _lock.ExitWriteLock();
+            }
+        }
+
+        public void OnUserDisconnected(HSUser user, Hub hub)
+        {
+            _lock.EnterWriteLock();
+            try
+            {
+                var hubConnection = FindHubConnection(hub);
+                if (hubConnection != null)
+                {
+                    if (_hubConnections.Remove(hubConnection))
+                    {
+                        var userHubConnections = FindHubConnectionByUserId(user.Id);
+                        if (userHubConnections.Count() == 0)
+                        {
+                            _connectedUsers.Remove(user.Id);
+                            // remove channel connections
+                            var channels = FindChannelConnectionsByUserId(user.Id);
+                            for (var i = 0; i < channels.Count(); i++)
+                            {
+                                var channel = channels.ElementAt(i);
+                                _channelConnections.Remove(channel);
+                            }
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                _lock.ExitWriteLock();
+            }
+        }
+
+        public void OnUserJoinedChannel(HSUser user, Hub hub, string channelName)
+        {
+            _lock.EnterWriteLock();
+            try
+            {
+                var channelConnection = FindChannelConnection(hub, channelName);
+                if (channelConnection == null)
+                {
+                    var connection = FindHubConnection(hub);
+                    if (connection == null)
+                    {
+                        connection = OnUserConnected(user, hub);
+                    }
+                    channelConnection = new HubChannelConnection(connection, channelName);
+                    _channelConnections.Add(channelConnection);
+
+                }
+            }
+            finally
+            {
+                _lock.ExitWriteLock();
+            }
+        }
+
+        public void OnUserLeftChannel(Hub hub, string channelName)
+        {
+            _lock.EnterWriteLock();
+            try
+            {
+                var channelConnection = FindChannelConnection(hub, channelName);
+                if (channelConnection != null)
+                {
+                    _channelConnections.Remove(channelConnection);
+                }
+            }
+            finally
+            {
+                _lock.ExitWriteLock();
+            }
+        }
+
+
+
+        public bool IsUserConnected(string userId)
+        {
+            try
+            {
+                _lock.EnterReadLock();
+                return _connectedUsers.ContainsKey(userId);
+            }
+            finally
+            {
+                _lock.ExitReadLock();
+            }
+        }
+
+     
+
+        public bool IsUserConnected(string userId, Type hubType)
+        {
+            try
+            {
+                _lock.EnterReadLock();
+                return (from c in _hubConnections
+                        where c.HubType == hubType && c.User.Id == userId
+                        select c).Any();
+            }
+            finally
+            {
+                _lock.ExitReadLock();
+            }
+        }
+
+        public bool IsUserConnected(string userId, Type hubType, string channelName)
+        {
+            try
+            {
+                _lock.EnterReadLock();
+                return (from c in _channelConnections
+                        where c.Connection.HubType == hubType && c.Connection.User.Id == userId && c.ChannelName == channelName
+                        select c).Any();
+            }
+            finally
+            {
+                _lock.ExitReadLock();
+            }
+        }
+      
+        public List<HSUser> GetConnectedUsers()
+        {
+            try
+            {
+                _lock.EnterReadLock();
+                return _connectedUsers.Values.ToList<HSUser>();
+            }
+            finally
+            {
+                _lock.ExitReadLock();
+            }
+        }
+
+        public List<HSUser> GetConnectedUsers(Type hubType)
+        {
+            try
+            {
+                _lock.EnterReadLock();
+                return (from c in _hubConnections
+                        where c.HubType == hubType
+                        select c.User).ToList();
+            }
+            finally
+            {
+                _lock.ExitReadLock();
+            }
+        }
+
+        public List<HSUser> GetConnectedUsers(Type hubType, string channelName)
+        {
+            try
+            {
+                _lock.EnterReadLock();
+                return (from c in _channelConnections
+                        where c.Connection.HubType == hubType && c.ChannelName == channelName
+                        select c.Connection.User).ToList();
+            }
+            finally
+            {
+                _lock.ExitReadLock();
+            }
+        }
+
+        public List<Type> GetUserHubs(string userId)
+        {
+            try
+            {
+                _lock.EnterReadLock();
+                return (from c in _hubConnections
+                        where c.User.Id == userId
+                        select c.HubType).Distinct().ToList();
+            }
+            finally
+            {
+                _lock.ExitReadLock();
+            }
+        }
+
+        public List<string> GetUserChannels(string userId, Type hubType)
+        {
+            try
+            {
+                _lock.EnterReadLock();
+                return (from c in _channelConnections
+                        where c.Connection.User.Id == userId && c.Connection.HubType == hubType
+                        select c.ChannelName).Distinct().ToList();
+            }
+            finally
+            {
+                _lock.ExitReadLock();
+            }
+        }
+
+    }
+}

--- a/src/Heisenslaught/Services/HubConnectionsService.cs
+++ b/src/Heisenslaught/Services/HubConnectionsService.cs
@@ -45,6 +45,11 @@ namespace Heisenslaught.Services
         private readonly List<HubChannelConnection> _channelConnections = new List<HubChannelConnection>();
 
 
+        public HubConnectionsService()
+        {
+            var a = 55;
+        }
+
         private HubConnection FindHubConnection(Hub hub)
         {
             return (from c in _hubConnections

--- a/src/Heisenslaught/Services/HubConnectionsService.cs
+++ b/src/Heisenslaught/Services/HubConnectionsService.cs
@@ -1,12 +1,9 @@
-﻿using System;
+﻿using Heisenslaught.Models.Users;
+using Microsoft.AspNetCore.SignalR;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
-using System.Collections.Concurrent;
-
 using System.Threading;
-using Heisenslaught.Models.Users;
-using Microsoft.AspNetCore.SignalR;
 
 namespace Heisenslaught.Services
 {
@@ -39,9 +36,7 @@ namespace Heisenslaught.Services
     
     public class HubConnectionsService : IHubConnectionsService
     {
-
         private readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
-
         private readonly Dictionary<string, HSUser> _connectedUsers = new Dictionary<string, HSUser>();
         private readonly List<HubConnection> _hubConnections = new List<HubConnection>();
         private readonly List<HubChannelConnection> _channelConnections = new List<HubChannelConnection>();
@@ -86,7 +81,6 @@ namespace Heisenslaught.Services
             _lock.EnterWriteLock();
             try
             {
-
                 var hubConnection = FindHubConnection(hub);
                 if (hubConnection == null)
                 {
@@ -153,7 +147,6 @@ namespace Heisenslaught.Services
                     }
                     channelConnection = new HubChannelConnection(connection, channelName, flag);
                     _channelConnections.Add(channelConnection);
-
                 }
             }
             finally
@@ -179,8 +172,6 @@ namespace Heisenslaught.Services
             }
         }
 
-
-
         public bool IsUserConnected(string userId)
         {
             try
@@ -193,8 +184,6 @@ namespace Heisenslaught.Services
                 _lock.ExitReadLock();
             }
         }
-
-     
 
         public bool IsUserConnected(string userId, Type hubType)
         {
@@ -353,9 +342,5 @@ namespace Heisenslaught.Services
             }
         }
 
-    }
-    class ChannelListItem
-    {
-        public string name;
     }
 }

--- a/src/Heisenslaught/Services/HubConnectionsService.cs
+++ b/src/Heisenslaught/Services/HubConnectionsService.cs
@@ -44,17 +44,11 @@ namespace Heisenslaught.Services
         private readonly List<HubConnection> _hubConnections = new List<HubConnection>();
         private readonly List<HubChannelConnection> _channelConnections = new List<HubChannelConnection>();
 
-
-        public HubConnectionsService()
-        {
-            var a = 55;
-        }
-
         private HubConnection FindHubConnection(Hub hub)
         {
             return (from c in _hubConnections
                     where c.HubType == hub.GetType() && c.ConnectionId == hub.Context.ConnectionId
-                    select c).First();
+                    select c).FirstOrDefault();
         }
 
         private IEnumerable<HubConnection> FindHubConnectionByUserId(string userId)
@@ -75,7 +69,7 @@ namespace Heisenslaught.Services
         {
             return (from c in _channelConnections
                     where c.ChannelName == channelName && c.Connection.HubType == hub.GetType() && c.Connection.ConnectionId == hub.Context.ConnectionId
-                    select c).First();
+                    select c).FirstOrDefault();
         }
 
         private HSUser GetConnectedUser(string userId)
@@ -235,7 +229,7 @@ namespace Heisenslaught.Services
             try
             {
                 _lock.EnterReadLock();
-                return _connectedUsers.Values.ToList<HSUser>();
+                return _connectedUsers.Values.Distinct().ToList<HSUser>();
             }
             finally
             {
@@ -250,7 +244,7 @@ namespace Heisenslaught.Services
                 _lock.EnterReadLock();
                 return (from c in _hubConnections
                         where c.HubType == hubType
-                        select c.User).ToList();
+                        select c.User).Distinct().ToList();
             }
             finally
             {
@@ -265,7 +259,7 @@ namespace Heisenslaught.Services
                 _lock.EnterReadLock();
                 return (from c in _channelConnections
                         where c.Connection.HubType == hubType && c.ChannelName == channelName
-                        select c.Connection.User).ToList();
+                        select c.Connection.User).Distinct().ToList();
             }
             finally
             {

--- a/src/Heisenslaught/Services/IDraftService.cs
+++ b/src/Heisenslaught/Services/IDraftService.cs
@@ -2,6 +2,7 @@
 using Heisenslaught.Infrastructure;
 using System.Threading.Tasks;
 
+
 namespace Heisenslaught.Services
 {
     public interface IDraftService

--- a/src/Heisenslaught/Services/IDraftService.cs
+++ b/src/Heisenslaught/Services/IDraftService.cs
@@ -8,8 +8,8 @@ namespace Heisenslaught.Services
     {
         void ClientDisconnected(DraftHub hub);
         void CompleteDraft(DraftRoom room);
-        DraftConfigDTO ConnectToDraft(DraftHub hub, string draftToken, string authToken = null);
-        Task<DraftConfigAdminDTO> CreateDraft(CreateDraftDTO config, DraftHub hub);
+        Task<DraftConfigDTO> ConnectToDraftAsync(DraftHub hub, string draftToken, string authToken = null);
+        Task<DraftConfigAdminDTO> CreateDraftAsync(CreateDraftDTO config, DraftHub hub);
         DraftRoom GetDraftRoom(string draftToken, bool autoCreate = false);
     }
 }

--- a/src/Heisenslaught/Services/IHeroDataService.cs
+++ b/src/Heisenslaught/Services/IHeroDataService.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace Heisenslaught.Services
+{
+    public interface IHeroDataService
+    {
+        HeroData GetHeroById(string heroId);
+        List<HeroData> GetHeroes();
+        MapData GetMapById(string mapId);
+        List<MapData> GetMaps();
+    }
+}

--- a/src/Heisenslaught/Services/IHubConnectionsService.cs
+++ b/src/Heisenslaught/Services/IHubConnectionsService.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using Heisenslaught.Models.Users;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Heisenslaught.Services
+{
+    public interface IHubConnectionsService
+    {
+        List<HSUser> GetConnectedUsers();
+        List<HSUser> GetConnectedUsers(Type hubType);
+        List<HSUser> GetConnectedUsers(Type hubType, string channelName);
+        List<string> GetUserChannels(string userId, Type hubType);
+        List<Type> GetUserHubs(string userId);
+        bool IsUserConnected(string userId);
+        bool IsUserConnected(string userId, Type hubType);
+        bool IsUserConnected(string userId, Type hubType, string channelName);
+        HubConnection OnUserConnected(HSUser user, Hub hub);
+        void OnUserDisconnected(HSUser user, Hub hub);
+        void OnUserJoinedChannel(HSUser user, Hub hub, string channelName);
+        void OnUserLeftChannel(Hub hub, string channelName);
+    }
+}

--- a/src/Heisenslaught/Services/IHubConnectionsService.cs
+++ b/src/Heisenslaught/Services/IHubConnectionsService.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using Heisenslaught.Models.Users;
+﻿using Heisenslaught.Models.Users;
 using Microsoft.AspNetCore.SignalR;
+using System;
+using System.Collections.Generic;
 
 namespace Heisenslaught.Services
 {

--- a/src/Heisenslaught/Services/IHubConnectionsService.cs
+++ b/src/Heisenslaught/Services/IHubConnectionsService.cs
@@ -10,6 +10,7 @@ namespace Heisenslaught.Services
         List<HSUser> GetConnectedUsers();
         List<HSUser> GetConnectedUsers(Type hubType);
         List<HSUser> GetConnectedUsers(Type hubType, string channelName);
+        HSUser GetUserFromConnection(string connectionId);
         List<string> GetUserChannels(string userId, Type hubType);
         List<Type> GetUserHubs(string userId);
         bool IsUserConnected(string userId);
@@ -17,7 +18,10 @@ namespace Heisenslaught.Services
         bool IsUserConnected(string userId, Type hubType, string channelName);
         HubConnection OnUserConnected(HSUser user, Hub hub);
         void OnUserDisconnected(HSUser user, Hub hub);
-        void OnUserJoinedChannel(HSUser user, Hub hub, string channelName);
+        void OnUserJoinedChannel(HSUser user, Hub hub, string channelName, int flag = 0);
         void OnUserLeftChannel(Hub hub, string channelName);
+        TReturn Query<TReturn>(Func<Dictionary<string, HSUser>, TReturn> query);
+        TReturn Query<TReturn>(Func<List<HubConnection>, TReturn> query);
+        TReturn Query<TReturn>(Func<List<HubChannelConnection>, TReturn> query);
     }
 }

--- a/src/Heisenslaught/Startup.cs
+++ b/src/Heisenslaught/Startup.cs
@@ -78,7 +78,6 @@ namespace Heisenslaught
             });
 
             // services
-            services.AddSingleton<IHubConnectionsService, HubConnectionsService>();
             services.AddSingleton<IDraftService, DraftService>();
             services.AddSingleton<IHeroDataService, HeroDataService>();
           
@@ -91,6 +90,8 @@ namespace Heisenslaught
             services.AddSingleton<RoleManager<HSRole>, RoleManager<HSRole>>();
             services.AddSingleton<UserManager<HSUser>, UserManager<HSUser>>();
             services.AddScoped<SignInManager<HSUser>, SignInManager<HSUser>>();
+
+            services.AddSingleton<IHubConnectionsService, HubConnectionsService>();
             
             // initialize Identity
             services.AddIdentity<HSUser, HSRole>()

--- a/src/Heisenslaught/Startup.cs
+++ b/src/Heisenslaught/Startup.cs
@@ -82,7 +82,7 @@ namespace Heisenslaught
                 var db = client.GetDatabase(options.Value.Database);
                 return new DraftStore(db, logger);
             });
-       
+
 
             /*
             services.AddSingleton<IUserRoleStore<HSUser>>(provider =>
@@ -95,8 +95,9 @@ namespace Heisenslaught
             });
             */
             // services
+            services.AddSingleton<IHubConnectionsService, HubConnectionsService>();
             services.AddSingleton<IDraftService, DraftService>();
-            services.AddSingleton<HeroDataService, HeroDataService>();
+            services.AddSingleton<IHeroDataService, HeroDataService>();
             
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
@@ -110,8 +111,6 @@ namespace Heisenslaught
             services.AddIdentity<HSUser, HSRole>()
                 .AddDefaultTokenProviders();
             services.AddOptions();
-
-
 
 
             services.AddMvc();

--- a/src/Heisenslaught/Startup.cs
+++ b/src/Heisenslaught/Startup.cs
@@ -1,25 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using AspNet.Security.OAuth.BattleNet;
+using Heisenslaught.Config;
+using Heisenslaught.Models.Users;
+using Heisenslaught.Persistence.Draft;
+using Heisenslaught.Persistence.User;
+using Heisenslaught.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using System.IO;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Configuration;
-
-using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.HttpOverrides;
-using Heisenslaught.Models.Users;
-using Heisenslaught.Persistence.User;
 using Microsoft.AspNetCore.Identity;
-using MongoDB.Driver;
-using AspNet.Security.OAuth.BattleNet;
-using Heisenslaught.Config;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Heisenslaught.Persistence.Draft;
-using Heisenslaught.Services;
+using MongoDB.Driver;
+
 
 namespace Heisenslaught
 {
@@ -86,6 +81,8 @@ namespace Heisenslaught
             services.AddSingleton<IHubConnectionsService, HubConnectionsService>();
             services.AddSingleton<IDraftService, DraftService>();
             services.AddSingleton<IHeroDataService, HeroDataService>();
+          
+
             
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
@@ -106,7 +103,9 @@ namespace Heisenslaught
             });
             services.AddSignalR(options=> {
                 options.Hubs.EnableDetailedErrors = true;
+                
             });
+           
             services.AddRouting(options => {
                 options.LowercaseUrls = true;
             });

--- a/src/Heisenslaught/Startup.cs
+++ b/src/Heisenslaught/Startup.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MongoDB.Driver;
-
+using System;
 
 namespace Heisenslaught
 {
@@ -94,7 +94,10 @@ namespace Heisenslaught
 
             
             // initialize Identity
-            services.AddIdentity<HSUser, HSRole>()
+            services.AddIdentity<HSUser, HSRole>(options=> {
+                options.Cookies.ExternalCookie.ExpireTimeSpan = TimeSpan.FromHours(1);
+                options.Cookies.ApplicationCookie.ExpireTimeSpan = TimeSpan.FromHours(1);
+            })
                 .AddDefaultTokenProviders();
             services.AddOptions();
 

--- a/src/Heisenslaught/Startup.cs
+++ b/src/Heisenslaught/Startup.cs
@@ -78,6 +78,7 @@ namespace Heisenslaught
             });
 
             // services
+            services.AddSingleton<IHubConnectionsService, HubConnectionsService>();
             services.AddSingleton<IDraftService, DraftService>();
             services.AddSingleton<IHeroDataService, HeroDataService>();
           
@@ -91,7 +92,6 @@ namespace Heisenslaught
             services.AddSingleton<UserManager<HSUser>, UserManager<HSUser>>();
             services.AddScoped<SignInManager<HSUser>, SignInManager<HSUser>>();
 
-            services.AddSingleton<IHubConnectionsService, HubConnectionsService>();
             
             // initialize Identity
             services.AddIdentity<HSUser, HSRole>()

--- a/src/HeisenslaughtUI/src/app/modules/heroes-draft-service/services/types/draft-users.ts
+++ b/src/HeisenslaughtUI/src/app/modules/heroes-draft-service/services/types/draft-users.ts
@@ -1,0 +1,5 @@
+export interface IDraftUser {
+    id: string;
+    name: string;
+    connectionTypes: number;
+}

--- a/src/HeisenslaughtUI/src/app/modules/heroes-drafting/components/draft-connection-status/draft-connection-status.component.html
+++ b/src/HeisenslaughtUI/src/app/modules/heroes-drafting/components/draft-connection-status/draft-connection-status.component.html
@@ -2,5 +2,23 @@
   <md-icon [ngClass]="[connectionStatus]" [attr.title]="connectionStatus">{{connectionIcon}}</md-icon>
 </div>
 <div class="connected-clients" *ngIf="connectionCount">
-  <span class="count">{{connectionCount}}</span><md-icon >people</md-icon>
+  <span class="count">{{connectionCount}}</span>
+  <md-icon>people</md-icon>
+  <app-tooltip [origin]="{originX:'end', originY:'bottom'}" [position]="{overlayX:'end', overlayY:'top'}">
+    <div class="connected-client-list">
+      <table>
+        <tr *ngFor="let user of connectedUsers">
+          <td class="left">
+            <md-icon *ngIf="status(user).obs" class="obs">remove_red_eye</md-icon>
+            <md-icon *ngIf="status(user).d2" class="team2">looks_two</md-icon>
+            <md-icon *ngIf="status(user).d1" class="team1">looks_one</md-icon>
+          </td>
+          <td class="center">{{user.name}}</td>
+          <td  class="right">
+            <md-icon *ngIf="status(user).admin" class="admin">edit</md-icon>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </app-tooltip>
 </div>

--- a/src/HeisenslaughtUI/src/app/modules/heroes-drafting/components/draft-connection-status/draft-connection-status.component.scss
+++ b/src/HeisenslaughtUI/src/app/modules/heroes-drafting/components/draft-connection-status/draft-connection-status.component.scss
@@ -53,6 +53,60 @@ $spinSpeed: 1000ms;
     clear: both;
 }
 
+.connected-client-list{
+    color: white;
+    padding:8px;
+    border: 1px solid darkcyan;
+    background-color: black;
+    font-weight: 400;
+    font-size:14px;
+    table{
+        border-spacing: 0px;
+        
+        td{
+            vertical-align: middle;
+            line-height:0px; 
+            padding:0px;
+        }
+        
+
+        .left{
+            text-align: right;
+        }
+        .center{
+            padding-left:4px;
+            padding-right:20px;
+            min-width: 128px;
+        }
+        .right{
+            text-align: right;
+            white-space: nowrap;
+           
+          
+        }
+        md-icon{
+            font-size: 20px;
+            width:20px;
+            height:20px;
+            color: black;
+            text-shadow: 0 0 8px white,0 0 2px white, 0 0 0.5px white,0 0 0.5px white,0 0 0.5px white, 0 0 0.5px white ;
+            margin-left: 4px;
+            
+            &:first-of-type{
+                margin-left: 0px;
+            }
+
+            &.team1{
+                color:darkblue;
+            }
+            &.team2{
+                color:darkred;
+            }
+        }
+    }
+}
+
+
 @-ms-keyframes spin {
     from {
         -ms-transform: rotate(0deg);

--- a/src/HeisenslaughtUI/tslint.json
+++ b/src/HeisenslaughtUI/tslint.json
@@ -28,7 +28,7 @@
       "variables-before-functions"
     ],
     "no-arg": true,
-    "no-bitwise": true,
+    "no-bitwise": false,
     "no-console": [
       true,
       "debug",


### PR DESCRIPTION
User connections are now being tracked. 

When a user connects to a draft they are sent a list of users that are also connected to the draft
Other users are sent join an leave messages as appropriate

the message is in the form of:
```c#
public class DraftRoomConnection
{
    public string id;
    public string name;
    public int connectionTypes;
}
```

ConnectionTypes is a bit flag indicating how the user is connected

```c#
 [Flags]
 public enum DraftConnectionType
 {
    DRAFTER_TEAM_1 = 1,
    DRAFTER_TEAM_2 = 2,
    OBSERVER = 4,
    ADMIN = 8
}
```

completes #69, #70